### PR TITLE
Publish results from freeipa-pr-ci2

### DIFF
--- a/src/gitHub.js
+++ b/src/gitHub.js
@@ -1,4 +1,4 @@
-export const DEFAULT_OWNER = 'freeipa';
+export const DEFAULT_OWNER = 'freeipa-pr-ci2';
 export const DEFAULT_REPO = 'freeipa';
 export const GITHUB_FETCH_LIMIT = 50;
 const TOKEN_KEY = 'github_token';


### PR DESCRIPTION
This commit is redirecting official ci.freeipa.org to the fork (freeipa-pr-ci2)
where all Nightly Regressions are running (refer to [1]). This way we will recover
history for all the Nightly Regressions (main purpose of pr-ci dashboard). However,
this will provoke that the history from Pull Requests testing, which is done in
freeipa project, will not be published in the dashboard (GiHub UI can be used for
looking into PRs results).

[1] https://lists.fedoraproject.org/archives/list/freeipa-devel@lists.fedorahosted.org/thread/PVR3KHXQDNDA7EL5AX6EZID2VMEPC4D2/